### PR TITLE
Feat: 즉시판매 구현 [#22]

### DIFF
--- a/src/main/java/com/programmers/dev/kream/purchasebidding/domain/PurchaseBidding.java
+++ b/src/main/java/com/programmers/dev/kream/purchasebidding/domain/PurchaseBidding.java
@@ -35,6 +35,15 @@ public class PurchaseBidding {
 
     protected PurchaseBidding() { }
 
+    public PurchaseBidding(Long purchaseBidderId, Long sizedProductId, Long price, Status status, LocalDateTime startDate, LocalDateTime dueDate) {
+        this.purchaseBidderId = purchaseBidderId;
+        this.sizedProductId = sizedProductId;
+        this.price = price;
+        this.status = status;
+        this.startDate = startDate;
+        this.dueDate = dueDate;
+    }
+
     public Long getId() {
         return id;
     }
@@ -61,5 +70,9 @@ public class PurchaseBidding {
 
     public LocalDateTime getDueDate() {
         return dueDate;
+    }
+
+    public void changeStatus(Status status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/programmers/dev/kream/sellbidding/domain/SellBidding.java
+++ b/src/main/java/com/programmers/dev/kream/sellbidding/domain/SellBidding.java
@@ -1,6 +1,7 @@
 package com.programmers.dev.kream.sellbidding.domain;
 
 import com.programmers.dev.kream.common.bidding.Status;
+import com.programmers.dev.kream.purchasebidding.domain.PurchaseBidding;
 import com.programmers.dev.kream.sellbidding.ui.SellBiddingRequest;
 import jakarta.persistence.*;
 
@@ -36,6 +37,13 @@ public class SellBidding {
 
     protected SellBidding() { }
 
+    /**
+     * 판매 입찰 등록시 사용하는 Constructor
+     * @param sellBidderId : 판매자 id
+     * @param sizedProductId : 상품 id
+     * @param price : 판매 입찰 가격
+     * @param dueDate : 입찰 마감 기한
+     */
     private SellBidding(Long sellBidderId, Long sizedProductId, Integer price, Long dueDate) {
         this.sellBidderId = sellBidderId;
         this.sizedProductId = sizedProductId;
@@ -45,12 +53,52 @@ public class SellBidding {
         this.dueDate = startDate.plusDays(dueDate);
     }
 
+    /**
+     * 구매 입찰에 등록된 건을 거래하려고 하는 경우 사용하는 Constructor
+     * @param sellBidderId  : 판매자 id
+     * @param sizedProductId : 상품 id
+     * @param price : 판매 입찰 가격
+     * @param dueDate : 입찰 마감 기한
+     */
+    private SellBidding(Long sellBidderId, Long sizedProductId, Integer price, LocalDateTime dueDate) {
+        this.sellBidderId = sellBidderId;
+        this.sizedProductId = sizedProductId;
+        this.price = price;
+        this.status = Status.SHIPPED;
+        this.startDate = LocalDateTime.now();
+        this.dueDate = dueDate;
+    }
+
+    /**
+     * 판매 입찰 등록시 사용하는 Constructor
+     * @param sellBidderId : 판매자 id
+     * @param sizedProductId : 상품 id
+     * @param sellBiddingRequest : 판매 입찰 정보
+     * @return  SellBidding
+     */
     public static SellBidding of(Long sellBidderId, Long sizedProductId, SellBiddingRequest sellBiddingRequest) {
         return new SellBidding(
                 sellBidderId,
                 sizedProductId,
                 sellBiddingRequest.price(),
                 sellBiddingRequest.dueDate());
+    }
+
+    /**
+     * todo : 구매입찰과 가격 타입 일치화 시키기
+     * todo : 입찰이 성사 됐을 때 성사된 날짜를 가지는 컬럼을 가지는 것은 어떠 할 지 논의
+     * 구매 입찰에 등록된 건을 거래하려고 하는 경우 사용하는 Constructor
+     * @param sellBidderId : 판매자 id
+     * @param purchaseBidding : 구매 입찰
+     * @return  SellBidding
+     */
+    public static SellBidding of(Long sellBidderId, PurchaseBidding purchaseBidding) {
+        return new SellBidding(
+                sellBidderId,
+                purchaseBidding.getSizedProductId(),
+                Integer.valueOf(purchaseBidding.getPrice().toString()),
+                purchaseBidding.getDueDate()
+        );
     }
 
     public Long getId() {

--- a/src/main/java/com/programmers/dev/kream/sellbidding/ui/SellBiddingController.java
+++ b/src/main/java/com/programmers/dev/kream/sellbidding/ui/SellBiddingController.java
@@ -38,4 +38,20 @@ public class SellBiddingController {
                 sellBiddingService.saveSellBidding(userId, sizedProductId, sellBiddingRequest)
         );
     }
+
+    /**
+     * 구매 입찰에 등록된 건 판매 API
+     * todo : 추후에 로그인 기능을 사용할 경우 Cookie로 값을 받아 올 수 있도록 구현
+     * @param userId : 판매자 id
+     * @param purchaseBiddingId : 구매 입찰 id
+     */
+    @PostMapping("/transact")
+    public ResponseEntity<SellBiddingResponse> transactPurchaseBidding(
+            @RequestParam Long userId,
+            @RequestParam Long purchaseBiddingId
+    ) {
+        SellBiddingResponse sellBiddingResponse = sellBiddingService.transactPurchaseBidding(userId, purchaseBiddingId);
+
+        return ResponseEntity.ok(sellBiddingResponse);
+    }
 }


### PR DESCRIPTION
# 구현사항 
- 구매입찰이 등록된 건에 대해서 판매를 하려고 할 때 사용하는 API 
- 거래체결이 되는 경우 현재는 배송상태를 SHIPPED로 가정을 했었습니다. 
  - 해당 부분의 경우 형진님은 다른 배송상태로 구현을 하셨던 것을 확인했습니다. 
  - 이 부분의 경우 dev에 합쳐졌을 때 토론 후에 변경하도록 하겠습니다. 

# 건의사항
- 입찰 로직을 구현하면서 거래가 성사된 날짜를 놔두는 것도 필요하다고 판단을 했습니다. (e.g trasactDate)
  - 해당 로직을 고안하게 된 이유 
    - 현재 입찰 등록 날짜, 마감 날짜만 존재해서 언제 거래가 체결 됐는지 판단이 어렵겠다는 생각을 했습니다. 
    - 마감날짜를 변경하는 식으로 구현 할 까 했지만 `비즈니스적인 로직`을 생각 했을 땐 컬럼을 추가하는 것이 좋겠다고 판단했습니다. 