### PR TITLE
Chore: 1차 MVP 배포에 필요한 설정 파일 추가 [#33]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### .DS_Store ###
+.DS_Store
+
+### kream logs ###
+logs/*.txt

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
   profiles:
     active: dev
-
   datasource:
     url: jdbc:h2:mem:kream;MODE=MYSQL;DB_CLOSE_DELAY=-1
     username: sa
@@ -21,10 +20,17 @@ spring:
       mode: embedded
       data-locations: classpath:sql/data.sql
       encoding: UTF-8
-
   h2:
     console:
       enabled: true
 
 logging:
-  config: classpath:logback-${spring.profiles.active}.xml
+  config: classpath:log/logback-${spring.profiles.active}.xml
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  jpa:
+    show-sql: false

--- a/src/main/resources/log/logback-dev.xml
+++ b/src/main/resources/log/logback-dev.xml
@@ -1,9 +1,12 @@
 <configuration scan="true" scanPeriod="30 seconds">
+    <property name="CONSOLE_LOG_PATTERN" value="%red(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %highlight(%5level) %cyan(%logger) - (%msg%n)"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%red(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %highlight(%5level) %cyan(%logger) - (%msg%n)</pattern>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
         </encoder>
     </appender>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/src/main/resources/log/logback-prod.xml
+++ b/src/main/resources/log/logback-prod.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <property name="FILE_LOG_PATTERN" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -- %msg%n"/>
+
+    <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/kream-%d{yyyy-MM-dd}.%i.txt</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>60</maxHistory>
+            <totalSizeCap>2GB</totalSizeCap>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ROLLING" />
+    </root>
+</configuration>


### PR DESCRIPTION
# 📌 설명 
### 1️⃣ application.yml
profile이 운영 환경(prod)일 때는 sql이 console에 출력되지 않게 `spring.jpa.show-sql: false` 설정을 추가했습니다. 
profile이 운영 환경(prod)일 때는 개발 환경(dev)의 로그 파일인 logback-dev.xml 파일은 실행되지 않습니다.

### 2️⃣ logback-prod.xml
profile이 운영 환경(prod)일 때, txt 파일로 로그를 관리할 수 있는 RollingFileAppender 를 추가했습니다.

- 저장 위치: logs/kream-{yyyy-MM-dd}.%i.txt
- 최대 파일 크기: 10MB(10MB 초과 할 경우  다음 i로 생성)
- 보관기간: 60일
- 최대 저장 공간: 2GB

### 3️⃣ .gitignore
로그 파일을 무시하도록 설정했습니다.