### PR TITLE
Refactor: release 1.0 배포 전 코드 리팩토링 수행 [#35]

### DIFF
--- a/src/main/java/com/programmers/dev/kream/purchasebidding/application/PurchaseBiddingService.java
+++ b/src/main/java/com/programmers/dev/kream/purchasebidding/application/PurchaseBiddingService.java
@@ -52,18 +52,11 @@ public class PurchaseBiddingService {
         User seller = userRepository.findById(sellBidding.getSellBidderId())
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다. " + sellBidding.getSellBidderId()));
 
-        /*
-            즉시 입찰 구매
-            -구매자: 바로 계좌에서 결제된 가격만큼 인출
-            -판매자: 판매자가 상품을 발송한 후 검수 합격이 완료가 된 다음날 입금
-                -> 1차 스프린트에서는 배송과정 생략 후 검수 합격부터 시작하는 시나리오
-                   구매자, 판매자 계좌에 바로 거래가 반영되도록 구현함.
-         */
-        sellBidding.changeStatus(Status.AUTHENTICATED);
+        sellBidding.changeStatus(Status.SHIPPED);
         bankService.accountTransaction(purchaser, seller, sellBidding.getPrice());
 
         return purchaseBiddingRepository.save(
-                new PurchaseBidding(purchaserId, request.sizedProductId(), request.price(), Status.AUTHENTICATED)).getId();
+                new PurchaseBidding(purchaserId, request.sizedProductId(), request.price(), Status.SHIPPED)).getId();
     }
 
     @Transactional

--- a/src/main/java/com/programmers/dev/kream/purchasebidding/ui/PurchaseBiddingController.java
+++ b/src/main/java/com/programmers/dev/kream/purchasebidding/ui/PurchaseBiddingController.java
@@ -29,11 +29,6 @@ public class PurchaseBiddingController {
         this.productService = productService;
     }
 
-    /**
-     * [상품 구입 선택 화면]
-     * @param productId : 구입하고 싶은 제품번호
-     * @return : 제품이름, 사이즈 별 최저가
-     */
     @GetMapping("/{productId}")
     public ResponseEntity<PurchaseSelectView> getProductSelectView(@PathVariable Long productId) {
         ProductResponse product = productService.findById(productId);
@@ -42,11 +37,6 @@ public class PurchaseBiddingController {
         return ResponseEntity.ok(new PurchaseSelectView(product.name(), biddingSelectLines));
     }
 
-    /**
-     * [즉시 구매]
-     * @param request : 구매가격, 상품번호
-     * @return : 구매입찰ID
-     */
     @PostMapping("/purchase-now")
     public ResponseEntity<PurchaseBiddingResponse> purchaseNow(@RequestBody PurchaseBiddingNowRequest request) {
         Long purchaseBiddingId = purchaseBiddingService.purchaseNow(getPurchaserId(), request);
@@ -54,11 +44,6 @@ public class PurchaseBiddingController {
         return ResponseEntity.ok(new PurchaseBiddingResponse(purchaseBiddingId));
     }
 
-    /**
-     * [입찰 구매]
-     * @param request : 입찰희망가격, 상품번호, 입찰기간
-     * @return : 구매입찰ID
-     */
     @PostMapping("/bid")
     public ResponseEntity<PurchaseBiddingResponse> bid(@RequestBody PurchaseBiddingBidRequest request) {
         Long purchaseBiddingId = purchaseBiddingService.bid(getPurchaserId(), request);

--- a/src/test/java/com/programmers/dev/kream/purchasebidding/application/PurchaseBiddingNowTest.java
+++ b/src/test/java/com/programmers/dev/kream/purchasebidding/application/PurchaseBiddingNowTest.java
@@ -64,7 +64,7 @@ class PurchaseBiddingNowTest {
 
         //then
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(purchaseBidding.getStatus()).isEqualTo(Status.AUTHENTICATED);
+            soft.assertThat(purchaseBidding.getStatus()).isEqualTo(Status.SHIPPED);
             soft.assertThat(purchaser.getAccount()).isEqualTo(0L);
         });
     }


### PR DESCRIPTION
# 📌 설명 
### 1️⃣ PurchaseBiddingController
메서드의 상태를 나타내는 주석을 제거했습니다.

### 2️⃣ PurchaseBiddingService, PurchaseBiddingNowTest
purchaseNow() 메서드에서 즉시구매 거래 후 구매/판매 입찰 엔티티의 `STATUS` 를 `SHIPPED` 으로 설정했습니다. 
해당 로직의 영향을 받는 PurchaseBiddingNowTest 파일도 그에 맞게 변경하였습니다.
