### PR TITLE
Test: REST Docs를 사용한 문서 자동화 공통화 작업 [#32]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.3'
     id 'io.spring.dependency-management' version '1.1.3'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.programmers.dev'
@@ -11,8 +12,19 @@ java {
     sourceCompatibility = '17'
 }
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    asciidoctorExtensions
+}
+
 repositories {
     mavenCentral()
+}
+
+ext {
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
@@ -21,8 +33,41 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    // ascii
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 tasks.named('test') {
+    outputs.dir snippetsDir
     useJUnitPlatform()
+}
+
+tasks.named('asciidoctor') {
+    doFirst {
+        delete file("src/main/resources/static/docs")
+    }
+
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExtensions'
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+
+    copy {
+        from "${asciidoctor.outputDir}"
+        into "src/main/resources/static/docs"
+    }
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,13 @@
+= KREAM API 문서
+:doctype: book
+:icons: front
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+[[Product-API]]
+== Product API
+
+[[Product-단일-조회]]
+=== Product 단일 조회
+operation::find-all-brands[]

--- a/src/test/java/com/programmers/dev/kream/product/ui/BrandControllerTest.java
+++ b/src/test/java/com/programmers/dev/kream/product/ui/BrandControllerTest.java
@@ -5,24 +5,38 @@ import com.programmers.dev.kream.product.application.BrandService;
 import com.programmers.dev.kream.product.ui.dto.BrandResponse;
 import com.programmers.dev.kream.product.ui.dto.BrandSaveRequest;
 import com.programmers.dev.kream.product.ui.dto.BrandsGetResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 
 @WebMvcTest(BrandController.class)
 class BrandControllerTest {
@@ -35,6 +49,20 @@ class BrandControllerTest {
 
     @Autowired
     ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup(
+        WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentationContextProvider
+    ) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .apply(documentationConfiguration(restDocumentationContextProvider)
+                .operationPreprocessors()
+                .withRequestDefaults(modifyUris().host("localhost").port(8080), prettyPrint())
+                .withResponseDefaults(modifyUris().host("localhost").port(8080), prettyPrint()))
+            .build();
+    }
 
     @Test
     @DisplayName("브랜드 등록을 할 수 있다.")

--- a/src/test/java/com/programmers/dev/kream/product/ui/ProductControllerTest.java
+++ b/src/test/java/com/programmers/dev/kream/product/ui/ProductControllerTest.java
@@ -4,13 +4,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.programmers.dev.kream.product.application.ProductService;
 import com.programmers.dev.kream.product.domain.ProductInfo;
 import com.programmers.dev.kream.product.ui.dto.*;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,6 +23,9 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -36,6 +44,20 @@ class ProductControllerTest {
 
     @MockBean
     ProductService productService;
+
+    @BeforeEach
+    void setup(
+        WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentationContextProvider
+    ) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .apply(documentationConfiguration(restDocumentationContextProvider)
+                .operationPreprocessors()
+                .withRequestDefaults(modifyUris().host("localhost").port(8080), prettyPrint())
+                .withResponseDefaults(modifyUris().host("localhost").port(8080), prettyPrint()))
+            .build();
+    }
 
     @Test
     @DisplayName("상품들을 조회할 수 있다.")

--- a/src/test/java/com/programmers/dev/kream/product/ui/SizedProductControllerTest.java
+++ b/src/test/java/com/programmers/dev/kream/product/ui/SizedProductControllerTest.java
@@ -3,17 +3,25 @@ package com.programmers.dev.kream.product.ui;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.programmers.dev.kream.product.domain.*;
 import com.programmers.dev.kream.product.ui.dto.SizedProductSaveRequest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,6 +45,19 @@ class SizedProductControllerTest {
     @Autowired
     SizedProductRepository sizedProductRepository;
 
+    @BeforeEach
+    void setup(
+        WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentationContextProvider
+    ) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .apply(documentationConfiguration(restDocumentationContextProvider)
+                .operationPreprocessors()
+                .withRequestDefaults(modifyUris().host("localhost").port(8080), prettyPrint())
+                .withResponseDefaults(modifyUris().host("localhost").port(8080), prettyPrint()))
+            .build();
+    }
 
     @Test
     @DisplayName("상품 조회 로직 검증")

--- a/src/test/java/com/programmers/dev/kream/purchasebidding/ui/PurchaseBiddingControllerTest.java
+++ b/src/test/java/com/programmers/dev/kream/purchasebidding/ui/PurchaseBiddingControllerTest.java
@@ -12,17 +12,25 @@ import com.programmers.dev.kream.purchasebidding.application.PurchaseBiddingServ
 import com.programmers.dev.kream.purchasebidding.domain.PurchaseSelectViewDao;
 import com.programmers.dev.kream.purchasebidding.ui.dto.BiddingSelectLine;
 import com.programmers.dev.kream.purchasebidding.ui.dto.PurchaseSelectView;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -46,6 +54,20 @@ class PurchaseBiddingControllerTest {
 
     @Autowired
     ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup(
+        WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentationContextProvider
+    ) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .apply(documentationConfiguration(restDocumentationContextProvider)
+                .operationPreprocessors()
+                .withRequestDefaults(modifyUris().host("localhost").port(8080), prettyPrint())
+                .withResponseDefaults(modifyUris().host("localhost").port(8080), prettyPrint()))
+            .build();
+    }
 
     @Test
     @DisplayName("구매자는 입찰 구입하고 싶은 제품번호의 제품이름과 사이즈 별 최저가를 확인할 수 있다.")

--- a/src/test/java/com/programmers/dev/kream/sellbidding/ui/SellBiddingControllerTest.java
+++ b/src/test/java/com/programmers/dev/kream/sellbidding/ui/SellBiddingControllerTest.java
@@ -14,6 +14,7 @@ import com.programmers.dev.kream.user.domain.UserRepository;
 import com.programmers.dev.kream.user.domain.UserRole;
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,12 +22,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cglib.core.Local;
+import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDateTime;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,6 +76,20 @@ class SellBiddingControllerTest {
 
     @Autowired
     SellBiddingRepository sellBiddingRepository;
+
+    @BeforeEach
+    void setup(
+        WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentationContextProvider
+    ) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .addFilter(new CharacterEncodingFilter("UTF-8", true))
+            .apply(documentationConfiguration(restDocumentationContextProvider)
+                .operationPreprocessors()
+                .withRequestDefaults(modifyUris().host("localhost").port(8080), prettyPrint())
+                .withResponseDefaults(modifyUris().host("localhost").port(8080), prettyPrint()))
+            .build();
+    }
   
     /**
      * todo : RestDocs 적용 후 api 명세화 하기


### PR DESCRIPTION
# 📌 설명

### 1️⃣ REST Docs를 위한 gradle설정을 변경하였습니다.

### 2️⃣ 공통 적용 부분인 @BeforEach를 전체 ControllerTest코드에 추가하였습니다.

### 3️⃣ src/docs/asciidoc/index.adoc 예시 파일을 만들었습니다.
- 하단 예시
<img width="745" alt="스크린샷 2023-09-05 오후 6 56 02" src="https://github.com/prgrms-be-devcourse/BE-04-CREAM/assets/78838534/46df372d-6623-4c0d-a262-685f80a90e63">
