### PR TITLE
경매 시작 및 종료에 따른 상태 변경 api 구현 및 테스트 작성 [#84]

### DIFF
--- a/module-api/src/main/java/com/programmers/dev/Auction/ui/AuctionController.java
+++ b/module-api/src/main/java/com/programmers/dev/Auction/ui/AuctionController.java
@@ -3,16 +3,15 @@ package com.programmers.dev.Auction.ui;
 import com.programmers.dev.Auction.application.AuctionService;
 import com.programmers.dev.Auction.dto.AuctionSaveRequest;
 import com.programmers.dev.Auction.dto.AuctionSaveResponse;
+import com.programmers.dev.Auction.dto.AuctionStatusChangeRequest;
+import com.programmers.dev.Auction.dto.AuctionStatusChangeResponse;
 import com.programmers.dev.exception.CreamException;
 import com.programmers.dev.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,11 +24,24 @@ public class AuctionController {
     public ResponseEntity<AuctionSaveResponse> saveAuction(
         @RequestBody @Validated AuctionSaveRequest auctionSaveRequest,
         BindingResult bindingResult) {
+        validateRequestBody(bindingResult);
 
-        if (bindingResult.hasErrors()) {
-            throw new CreamException(ErrorCode.INVALID_REQUEST_VALUE);
-        }
         return ResponseEntity.ok(auctionService.save(auctionSaveRequest));
     }
 
+    @PatchMapping("/status")
+    public ResponseEntity<AuctionStatusChangeResponse> changeAuctionStatus(
+        @RequestBody @Validated AuctionStatusChangeRequest auctionStatusChangeRequest,
+        BindingResult bindingResult
+    ) {
+        validateRequestBody(bindingResult);
+
+        return ResponseEntity.ok(auctionService.changeAuctionStatus(auctionStatusChangeRequest));
+    }
+
+    private static void validateRequestBody(BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            throw new CreamException(ErrorCode.INVALID_REQUEST_VALUE);
+        }
+    }
 }

--- a/module-api/src/test/resources/application.yml
+++ b/module-api/src/test/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  profiles:
+    active: test
+  jpa:
+    show-sql: true
+    

--- a/module-api/src/test/resources/application.yml
+++ b/module-api/src/test/resources/application.yml
@@ -3,4 +3,3 @@ spring:
     active: test
   jpa:
     show-sql: true
-    

--- a/module-domain/src/main/java/com/programmers/dev/Auction/application/AuctionService.java
+++ b/module-domain/src/main/java/com/programmers/dev/Auction/application/AuctionService.java
@@ -4,6 +4,7 @@ import com.programmers.dev.Auction.domain.Auction;
 import com.programmers.dev.Auction.domain.AuctionRepository;
 import com.programmers.dev.Auction.dto.AuctionSaveRequest;
 import com.programmers.dev.Auction.dto.AuctionSaveResponse;
+import com.programmers.dev.Auction.dto.AuctionStatusChangeRequest;
 import com.programmers.dev.common.AuctionStatus;
 import com.programmers.dev.exception.CreamException;
 import com.programmers.dev.product.domain.Product;
@@ -37,15 +38,9 @@ public class AuctionService {
     }
 
     @Transactional
-    public void startAuction(Long id) {
-        Auction auction = findAuctionById(id);
-        auction.changeStatus(AuctionStatus.ONGOING);
-    }
-
-    @Transactional
-    public void finishAuction(Long id) {
-        Auction auction = findAuctionById(id);
-        auction.changeStatus(AuctionStatus.FINISHED);
+    public void changeAuctionStatus(AuctionStatusChangeRequest auctionStatusChangeRequest) {
+        Auction auction = findAuctionById(auctionStatusChangeRequest.id());
+        auction.changeStatus(auctionStatusChangeRequest.auctionStatus());
     }
 
     private Auction findAuctionById(Long id) {

--- a/module-domain/src/main/java/com/programmers/dev/Auction/application/AuctionService.java
+++ b/module-domain/src/main/java/com/programmers/dev/Auction/application/AuctionService.java
@@ -5,6 +5,7 @@ import com.programmers.dev.Auction.domain.AuctionRepository;
 import com.programmers.dev.Auction.dto.AuctionSaveRequest;
 import com.programmers.dev.Auction.dto.AuctionSaveResponse;
 import com.programmers.dev.Auction.dto.AuctionStatusChangeRequest;
+import com.programmers.dev.Auction.dto.AuctionStatusChangeResponse;
 import com.programmers.dev.common.AuctionStatus;
 import com.programmers.dev.exception.CreamException;
 import com.programmers.dev.product.domain.Product;
@@ -38,9 +39,11 @@ public class AuctionService {
     }
 
     @Transactional
-    public void changeAuctionStatus(AuctionStatusChangeRequest auctionStatusChangeRequest) {
+    public AuctionStatusChangeResponse changeAuctionStatus(AuctionStatusChangeRequest auctionStatusChangeRequest) {
         Auction auction = findAuctionById(auctionStatusChangeRequest.id());
         auction.changeStatus(auctionStatusChangeRequest.auctionStatus());
+
+        return new AuctionStatusChangeResponse(auction.getId(), auction.getAuctionStatus());
     }
 
     private Auction findAuctionById(Long id) {

--- a/module-domain/src/main/java/com/programmers/dev/Auction/dto/AuctionStatusChangeRequest.java
+++ b/module-domain/src/main/java/com/programmers/dev/Auction/dto/AuctionStatusChangeRequest.java
@@ -1,0 +1,9 @@
+package com.programmers.dev.Auction.dto;
+
+import com.programmers.dev.common.AuctionStatus;
+
+public record AuctionStatusChangeRequest(
+    Long id,
+    AuctionStatus auctionStatus
+) {
+}

--- a/module-domain/src/main/java/com/programmers/dev/Auction/dto/AuctionStatusChangeRequest.java
+++ b/module-domain/src/main/java/com/programmers/dev/Auction/dto/AuctionStatusChangeRequest.java
@@ -1,9 +1,14 @@
 package com.programmers.dev.Auction.dto;
 
 import com.programmers.dev.common.AuctionStatus;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 public record AuctionStatusChangeRequest(
+    @NotNull
     Long id,
+
+    @NotNull
     AuctionStatus auctionStatus
 ) {
 }

--- a/module-domain/src/main/java/com/programmers/dev/Auction/dto/AuctionStatusChangeResponse.java
+++ b/module-domain/src/main/java/com/programmers/dev/Auction/dto/AuctionStatusChangeResponse.java
@@ -1,0 +1,10 @@
+package com.programmers.dev.Auction.dto;
+
+import com.programmers.dev.common.AuctionStatus;
+
+public record AuctionStatusChangeResponse(
+    Long auctionId,
+
+    AuctionStatus auctionStatus
+) {
+}

--- a/module-domain/src/test/java/com/programmers/dev/Auction/application/AuctionBiddingServiceTest.java
+++ b/module-domain/src/test/java/com/programmers/dev/Auction/application/AuctionBiddingServiceTest.java
@@ -2,9 +2,8 @@ package com.programmers.dev.Auction.application;
 
 import com.programmers.dev.Auction.domain.AuctionBidding;
 import com.programmers.dev.Auction.domain.AuctionBiddingRepository;
-import com.programmers.dev.Auction.dto.AuctionBidRequest;
-import com.programmers.dev.Auction.dto.AuctionBidResponse;
-import com.programmers.dev.Auction.dto.AuctionSaveRequest;
+import com.programmers.dev.Auction.dto.*;
+import com.programmers.dev.common.AuctionStatus;
 import com.programmers.dev.exception.CreamException;
 import com.programmers.dev.exception.ErrorCode;
 import com.programmers.dev.product.domain.*;
@@ -20,8 +19,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -63,9 +60,11 @@ class AuctionBiddingServiceTest {
             LocalDateTime.of(2023, 9, 13, 13, 30),
             LocalDateTime.of(2023, 9, 13, 15, 30));
 
-        Long savedAuctionId = auctionService.save(auctionSaveRequest);
+        AuctionSaveResponse auctionSaveResponse = auctionService.save(auctionSaveRequest);
 
-        auctionService.startAuction(savedAuctionId);
+        auctionService.changeAuctionStatus(new AuctionStatusChangeRequest(
+            auctionSaveResponse.auctionId(),
+            AuctionStatus.ONGOING));
 
         User user = new User(
             "aaa@mail.com",
@@ -76,7 +75,7 @@ class AuctionBiddingServiceTest {
             UserRole.ROLE_USER);
         userRepository.save(user);
 
-        AuctionBidRequest auctionBidRequest = new AuctionBidRequest(user.getId(), savedAuctionId, 4000L);
+        AuctionBidRequest auctionBidRequest = new AuctionBidRequest(user.getId(), auctionSaveResponse.auctionId(), 4000L);
 
         //when
         AuctionBidResponse auctionBidResponse = auctionBiddingService.bidAuction(auctionBidRequest);
@@ -106,7 +105,7 @@ class AuctionBiddingServiceTest {
             LocalDateTime.of(2023, 9, 13, 13, 30),
             LocalDateTime.of(2023, 9, 13, 15, 30));
 
-        Long savedAuctionId = auctionService.save(auctionSaveRequest);
+        AuctionSaveResponse auctionSaveResponse = auctionService.save(auctionSaveRequest);
 
         User user = new User(
             "aaa@mail.com",
@@ -117,7 +116,7 @@ class AuctionBiddingServiceTest {
             UserRole.ROLE_USER);
         userRepository.save(user);
 
-        AuctionBidRequest auctionBidRequest = new AuctionBidRequest(user.getId(), savedAuctionId, 4000L);
+        AuctionBidRequest auctionBidRequest = new AuctionBidRequest(user.getId(), auctionSaveResponse.auctionId(), 4000L);
 
         //when && then
         Assertions.assertThatThrownBy(() -> auctionBiddingService.bidAuction(auctionBidRequest))


### PR DESCRIPTION
## ✅ PR 종류
<!-- 체크박스에 "x"를 입력해주세요. -->
- [x] 기능 추가
- [ ] 기능 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 문서 추가/수정

 ## 📌 PR 요약
<!-- 한 두 줄로 간단하게 적어주세요. -->
- startAuction(), finishAuction() 메서드를 changeAuctionStatus()하나로 수행할 수 있게끔 리팩토링 하였습니다.
- 경매 시작 및 종료에 따른 상태 변경 api 구현 및 테스트 작성하였습니다.