### PR TITLE
Feat: 경매 입찰 취소 시 예외 처리 [#140]

### DIFF
--- a/module-domain/src/main/java/com/programmers/dev/Auction/application/AuctionBiddingService.java
+++ b/module-domain/src/main/java/com/programmers/dev/Auction/application/AuctionBiddingService.java
@@ -6,13 +6,13 @@ import com.programmers.dev.Auction.domain.AuctionBiddingRepository;
 import com.programmers.dev.Auction.domain.AuctionRepository;
 import com.programmers.dev.Auction.dto.*;
 import com.programmers.dev.exception.CreamException;
-import com.programmers.dev.exception.ErrorCode;
 import com.programmers.dev.user.domain.User;
 import com.programmers.dev.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.programmers.dev.exception.ErrorCode.INVALID_CANCEL_BIDDING;
 import static com.programmers.dev.exception.ErrorCode.INVALID_ID;
 
 @Service
@@ -44,10 +44,16 @@ public class AuctionBiddingService {
 
     @Transactional
     public void cancelAuctionBid(Long userId, AuctionBiddingCancelRequest request) {
-        auctionBiddingRepository.deleteLastAuctionBidding(userId, request.auctionId(), request.price());
+        AuctionBidding auctionBidding = getCancelAuctionBidding(userId, request);
+
+        auctionBiddingRepository.delete(auctionBidding);
     }
 
-    // TODO 인덱스 활용
+    private AuctionBidding getCancelAuctionBidding(Long userId, AuctionBiddingCancelRequest request) {
+        return auctionBiddingRepository.findCancelBidding(userId, request.auctionId(), request.price())
+            .orElseThrow(() -> new CreamException(INVALID_CANCEL_BIDDING));
+    }
+
     public BiddingPriceGetResponse getCurrentBiddingPrice(BiddingPriceGetRequest request) {
         Long topBiddingPrice = getTopBiddingPrice(request);
 

--- a/module-domain/src/main/java/com/programmers/dev/Auction/domain/AuctionBiddingRepository.java
+++ b/module-domain/src/main/java/com/programmers/dev/Auction/domain/AuctionBiddingRepository.java
@@ -16,9 +16,10 @@ public interface AuctionBiddingRepository extends JpaRepository<AuctionBidding, 
         "limit 1")
     Optional<AuctionBidding> findTopBiddingPrice(@Param("auctionId") Long auctionId);
 
-    @Modifying(clearAutomatically = true)
-    @Query("delete from AuctionBidding ab where ab.user.id = :userId and ab.auction.id = :auctionId and ab.price = :price")
-    void deleteLastAuctionBidding(
+
+    @Query("select ab from AuctionBidding ab " +
+        "where ab.user.id = :userId and ab.auction.id = :auctionId and ab.price = :price")
+    Optional<AuctionBidding> findCancelBidding(
         @Param("userId") Long userId,
         @Param("auctionId") Long auctionId,
         @Param("price") Long price);

--- a/module-domain/src/main/java/com/programmers/dev/exception/ErrorCode.java
+++ b/module-domain/src/main/java/com/programmers/dev/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     OVER_PRICE(BAD_REQUEST, BAD_REQUEST.value(), "too much bidding price"),
     INSUFFICIENT_ACCOUNT_MONEY(BAD_REQUEST, -201, "not enough account money"),
     INVALID_BIDDING_PRICE(BAD_REQUEST,BAD_REQUEST.value(),"please enter a higher price than the highest bid price"),
-    INVALID_CHANGE_STATUS(BAD_REQUEST,BAD_REQUEST.value(),"you cannot change ongoing or finished auction to before state")
+    INVALID_CHANGE_STATUS(BAD_REQUEST,BAD_REQUEST.value(),"you cannot change ongoing or finished auction to before state"),
+    INVALID_CANCEL_BIDDING(BAD_REQUEST,BAD_REQUEST.value(),"please check auction id and price")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## ✅ PR 종류
<!-- 체크박스에 "x"를 입력해주세요. -->
- [x] 기능 추가
- [ ] 기능 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 문서 추가/수정

 ## 📌 PR 요약
<!-- 한 두 줄로 간단하게 적어주세요. -->
- 경매 입찰 취소시 유효하지 않는 경매 입찰을 취소할 경우 예외 처리를 해주었습니다.
- delete쿼리를 바로 사용할 경우 위 사항에 대한 예외처리를 해줄 수 없어서 select쿼리를 사용하도록 리팩토링 하였습니다.
